### PR TITLE
feat: Use YTDL metadata to enrich index records

### DIFF
--- a/avsearch/src/avsearch.py
+++ b/avsearch/src/avsearch.py
@@ -133,9 +133,6 @@ class AVSearch:
             self._downloaded.append(file["filename"].encode("utf-8"))
 
     def _parse_segment(self, file: str, meta, segment):
-        chunks = file.split(".")[0].split("-")
-        video_id = chunks.pop()
-        video_title = "-".join(chunks)
         return {
             "objectID": str(uuid.uuid4()),
             "videoID": meta["id"],


### PR DESCRIPTION
Add the following fields to segment records using YTDL downloaded video metadat:

            "videoID": meta["id"],
            "videoTitle": meta["title"],
            "videoDescription": meta["description"],
            "url": f'https://youtu.be/{meta["id"]}?t={round(segment["start"], 2):.0f}',
            "thumbnail": meta['thumbnails'][0]['url'],

Metadata is retrieved once per video.