### PR TITLE
Fix metadata collection when using multiple videos

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "avsearch"
-version = "0.1.0"
+version = "0.1.1"
 description = "Automated YouTube Audio/Video content transcription search for your website"
 authors = ["Michael King <michael.king@algolia.com>", "Chuck Meyer <chuck.meyer@algolia.com>"]
 readme = "README.md"


### PR DESCRIPTION
I made a change so that the metadata collection step only runs once at the beginning when it downloads the videos. Beforehand, it was grabbing the metadata multiple times making the process take longer.

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.